### PR TITLE
[feat/#27] 문화생활 기록 전체 조회 API 연동

### DIFF
--- a/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
+++ b/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
@@ -1,14 +1,21 @@
 package com.example.baba.data.record
 
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.*
 
 interface DiaryApi {
+    @Multipart
     @POST("diaries")
     suspend fun createDiary(
-        @Query("id") userId: Long,
-        @Body diaryCreateRequest: DiaryCreateRequest
-    ): Response<Void>
+        @Part("id") userId: Long,
+        @Part("title") title: String,
+        @Part("content") content: String,
+        @Part("category") category: String,
+        @Part("rating") rating: Double,
+        @Part("watchedAt") watchedAt: String,
+        @Part imageFile: MultipartBody.Part? = null
+    ): Response<DiaryResponse>
 
     @GET("diaries/me")
     suspend fun getAllMyDiaries(@Query("id") userId: Long): Response<List<DiaryResponse>>

--- a/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
+++ b/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
@@ -9,4 +9,7 @@ interface DiaryApi {
         @Query("id") userId: Long,
         @Body diaryCreateRequest: DiaryCreateRequest
     ): Response<Void>
+
+    @GET("diaries/me")
+    suspend fun getAllMyDiaries(@Query("id") userId: Long): Response<List<DiaryResponse>>
 }

--- a/app/src/main/java/com/example/baba/data/record/DiaryModels.kt
+++ b/app/src/main/java/com/example/baba/data/record/DiaryModels.kt
@@ -9,3 +9,12 @@ data class DiaryCreateRequest(
     // val public: Boolean,
     // val spoiler: Boolean,
 )
+
+data class DiaryResponse(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val category: String,
+    val categoryLabel: String,
+    val createdDate: String
+)

--- a/app/src/main/java/com/example/baba/data/record/DiaryModels.kt
+++ b/app/src/main/java/com/example/baba/data/record/DiaryModels.kt
@@ -4,8 +4,9 @@ data class DiaryCreateRequest(
     val title: String,
     val content: String,
     val category: String,
-    val rating: Int,
-    val watchedAt: String
+    val rating: Double,
+    val watchedAt: String,
+    val image: String? = null
     // val public: Boolean,
     // val spoiler: Boolean,
 )
@@ -16,5 +17,7 @@ data class DiaryResponse(
     val content: String,
     val category: String,
     val categoryLabel: String,
-    val createdDate: String
+    val createdDate: String,
+    val image: String?,
+    val rating: Double
 )

--- a/app/src/main/java/com/example/baba/data/record/WatchedDataManager.kt
+++ b/app/src/main/java/com/example/baba/data/record/WatchedDataManager.kt
@@ -1,0 +1,52 @@
+package com.example.baba.data.record
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+object WatchedDateManager {
+    private var sharedPreferences: SharedPreferences? = null
+    private val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+    fun initialize(context: Context) {
+        if (sharedPreferences == null) {
+            sharedPreferences = context.getSharedPreferences("watched_dates", Context.MODE_PRIVATE)
+        }
+    }
+
+    fun setWatchedDate(diaryId: Long, date: LocalDate) {
+        sharedPreferences?.edit()
+            ?.putString("diary_$diaryId", date.format(dateFormatter))
+            ?.apply()
+    }
+
+    fun getWatchedDate(diaryId: Long): LocalDate? {
+        val dateString = sharedPreferences?.getString("diary_$diaryId", null)
+        return dateString?.let { LocalDate.parse(it, dateFormatter) }
+    }
+
+    fun removeWatchedDate(diaryId: Long) {
+        sharedPreferences?.edit()
+            ?.remove("diary_$diaryId")
+            ?.apply()
+    }
+
+    fun getAllWatchedDates(): Map<Long, LocalDate> {
+        val result = mutableMapOf<Long, LocalDate>()
+        sharedPreferences?.all?.forEach { (key, value) ->
+            if (key.startsWith("diary_") && value is String) {
+                val diaryId = key.removePrefix("diary_").toLongOrNull()
+                val date = try {
+                    LocalDate.parse(value, dateFormatter)
+                } catch (e: Exception) {
+                    null
+                }
+                if (diaryId != null && date != null) {
+                    result[diaryId] = date
+                }
+            }
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/example/baba/ui/home/CreateActivity.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateActivity.kt
@@ -26,12 +26,12 @@ class CreateActivity : ComponentActivity() {
             BABATheme {
                 var showDetail by remember { mutableStateOf(false) }
                 var title by remember { mutableStateOf("") }
-                var rating by remember { mutableStateOf(0f) }
+                var rating by remember { mutableStateOf(0.0) }
                 var review by remember { mutableStateOf("") }
                 var location by remember { mutableStateOf("") }
                 var isPublic by remember { mutableStateOf(true) }
                 var includeSpoiler by remember { mutableStateOf(false) }
-                val photos = remember { mutableStateListOf<Uri>() }
+                var photo by remember { mutableStateOf<Uri?>(null) }  // 단일 사진
 
                 // userId null 체크
                 val currentUserId = userId
@@ -46,9 +46,11 @@ class CreateActivity : ComponentActivity() {
                         selectedDate = initialDate,
                         title = title,
                         rating = rating,
+                        photo = photo,  // 사진 전달
                         onBack = { finish() },
                         onTitleChange = { title = it },
                         onRatingChange = { rating = it },
+                        onPhotoChange = { photo = it },  // 사진 변경 콜백
                         onNext = { showDetail = true }
                     )
                 } else {
@@ -57,7 +59,7 @@ class CreateActivity : ComponentActivity() {
                         category = initialCategory,
                         date = initialDate,
                         title = title,
-                        rating = rating,
+                        rating = rating.toFloat(),
                         review = review,
                         onReviewChange = { review = it },
                         location = location,
@@ -66,13 +68,9 @@ class CreateActivity : ComponentActivity() {
                         onPublicChange = { isPublic = it },
                         includeSpoiler = includeSpoiler,
                         onSpoilerChange = { includeSpoiler = it },
-                        photos = photos,
-                        onPhotosChange = {
-                            photos.clear()
-                            photos.addAll(it)
-                        },
-                        onRemovePhoto = { idx -> photos.removeAt(idx) },
-                        onBack = { finish() },
+                        photo = photo,  // 단일 사진 전달
+                        onPhotoChange = { photo = it },  // 사진 변경 콜백
+                        onBack = { showDetail = false },
                         onSave = {
                             // 저장 완료 후 화면 종료
                             Toast.makeText(this, "기록이 저장되었습니다.", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/baba/ui/home/CreateActivity.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
 import androidx.core.view.WindowCompat
 import com.example.baba.data.network.SessionManager.userId
+import com.example.baba.data.record.WatchedDateManager
 import com.example.baba.ui.theme.BABATheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -15,6 +16,9 @@ import java.time.format.DateTimeFormatter
 class CreateActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        WatchedDateManager.initialize(this)
+
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         val initialCategory = intent.getStringExtra("category") ?: "PERFORMANCE"

--- a/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
@@ -1,6 +1,9 @@
 package com.example.baba.ui.home
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
+import android.util.Base64
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -9,8 +12,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -34,6 +35,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.ByteArrayOutputStream
+import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -54,20 +60,32 @@ fun CreateDetailScreen(
     onPublicChange: (Boolean) -> Unit,
     includeSpoiler: Boolean,
     onSpoilerChange: (Boolean) -> Unit,
-    photos: List<Uri>,
-    onPhotosChange: (List<Uri>) -> Unit,  // 새로운 사진 리스트 반영용 콜백
-    onRemovePhoto: (Int) -> Unit,
+    photo: Uri?,  // 단일 사진
+    onPhotoChange: (Uri?) -> Unit,  // 사진 변경 콜백
     onBack: () -> Unit,
     onSave: () -> Unit
 ) {
     val context = LocalContext.current
 
-    // 갤러리 런처
+    // 갤러리 런처 (단일 이미지)
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
-        uri?.let {
-            onPhotosChange(photos + it) // 새 Uri 추가
+        onPhotoChange(uri)
+    }
+
+    fun uriToMultipart(uri: Uri): MultipartBody.Part? {
+        return try {
+            val inputStream = context.contentResolver.openInputStream(uri)
+            val tempFile = File.createTempFile("upload", ".jpg", context.cacheDir)
+            tempFile.outputStream().use { output ->
+                inputStream?.copyTo(output)
+            }
+            val requestFile = tempFile.asRequestBody("image/jpeg".toMediaTypeOrNull())
+            MultipartBody.Part.createFormData("imageFile", tempFile.name, requestFile)
+        } catch (e: Exception) {
+            Log.e("CreateDetail", "이미지 Multipart 변환 실패: ${e.message}")
+            null
         }
     }
 
@@ -83,30 +101,34 @@ fun CreateDetailScreen(
                 actions = {
                     TextButton(
                         onClick = {
-                            val request = DiaryCreateRequest(
-                                title = title,
-                                content = review,
-                                category = category,
-                                rating = rating.toInt(),
-                                watchedAt = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
-                            )
                             CoroutineScope(Dispatchers.IO).launch {
                                 try {
+                                    val imagePart = photo?.let { uriToMultipart(it) }
+
                                     val response = RetrofitInstance.diaryApi.createDiary(
                                         userId = userId,
-                                        diaryCreateRequest = request
+                                        title = title,
+                                        content = review,
+                                        category = category,
+                                        rating = rating.toDouble(),
+                                        watchedAt = date.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                                        imageFile = imagePart
                                     )
+
+
                                     withContext(Dispatchers.Main) {
                                         if (response.isSuccessful) {
                                             Toast.makeText(context, "기록 저장 성공", Toast.LENGTH_SHORT).show()
                                             onSave()
                                         } else {
                                             Toast.makeText(context, "저장 실패: ${response.code()}", Toast.LENGTH_SHORT).show()
+                                            Log.e("CreateDetail", "Error: ${response.errorBody()?.string()}")
                                         }
                                     }
                                 } catch (e: Exception) {
                                     withContext(Dispatchers.Main) {
                                         Toast.makeText(context, "에러: ${e.message}", Toast.LENGTH_SHORT).show()
+                                        Log.e("CreateDetail", "Exception: ${e.message}", e)
                                     }
                                 }
                             }
@@ -166,7 +188,7 @@ fun CreateDetailScreen(
             TextField(
                 value = review,
                 onValueChange = onReviewChange,
-                placeholder = { Text("‘$title’에 대해 어떻게 생각하시나요?") },
+                placeholder = { Text("'$title'에 대해 어떻게 생각하시나요?") },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(120.dp)
@@ -196,21 +218,22 @@ fun CreateDetailScreen(
                 }
             }
 
-            // 사진
+            // 사진 (단일)
             Text(text = "사진", fontSize = 16.sp, fontWeight = FontWeight.Medium)
-            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                item {
-                    Box(
-                        modifier = Modifier
-                            .size(80.dp)
-                            .background(Color.LightGray)
-                            .clickable { imagePickerLauncher.launch("image/*") },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Filled.Add, contentDescription = "사진 추가")
-                    }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                // 사진 추가 버튼
+                Box(
+                    modifier = Modifier
+                        .size(80.dp)
+                        .background(Color.LightGray)
+                        .clickable { imagePickerLauncher.launch("image/*") },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = "사진 추가")
                 }
-                itemsIndexed(photos) { idx, uri ->
+
+                // 선택된 사진 표시
+                photo?.let { uri ->
                     Box(modifier = Modifier.size(80.dp)) {
                         Image(
                             painter = rememberAsyncImagePainter(uri),
@@ -220,18 +243,36 @@ fun CreateDetailScreen(
                                 .padding(4.dp)
                         )
                         IconButton(
-                            onClick = {
-                                onPhotosChange(photos.toMutableList().apply { removeAt(idx) })
-                            },
+                            onClick = { onPhotoChange(null) },
                             modifier = Modifier.align(Alignment.TopEnd)
                         ) {
-                            Icon(Icons.Filled.Close, contentDescription = "삭제")
+                            Icon(Icons.Filled.Close, contentDescription = "삭제", tint = Color.Red)
                         }
                     }
                 }
             }
         }
     }
+}
+
+// 이미지 크기 조정 함수 (용량 최적화)
+fun resizeBitmap(bitmap: Bitmap, maxWidth: Int = 400, maxHeight: Int = 300): Bitmap {
+    val width = bitmap.width
+    val height = bitmap.height
+
+    val ratioBitmap = width.toFloat() / height.toFloat()
+    val ratioMax = maxWidth.toFloat() / maxHeight.toFloat()
+
+    var finalWidth = maxWidth
+    var finalHeight = maxHeight
+
+    if (ratioMax > ratioBitmap) {
+        finalWidth = (maxHeight.toFloat() * ratioBitmap).toInt()
+    } else {
+        finalHeight = (maxWidth.toFloat() / ratioBitmap).toInt()
+    }
+
+    return Bitmap.createScaledBitmap(bitmap, finalWidth, finalHeight, true)
 }
 
 fun getCategoryLabel(code: String): String {

--- a/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.material.icons.filled.StarHalf
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,7 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.example.baba.data.network.RetrofitInstance
-import com.example.baba.data.record.DiaryCreateRequest
+import com.example.baba.data.record.WatchedDateManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -66,6 +69,10 @@ fun CreateDetailScreen(
     onSave: () -> Unit
 ) {
     val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        WatchedDateManager.initialize(context)
+    }
 
     // 갤러리 런처 (단일 이미지)
     val imagePickerLauncher = rememberLauncherForActivityResult(
@@ -115,9 +122,11 @@ fun CreateDetailScreen(
                                         imageFile = imagePart
                                     )
 
-
                                     withContext(Dispatchers.Main) {
                                         if (response.isSuccessful) {
+                                            response.body()?.let { diaryResponse ->
+                                                WatchedDateManager.setWatchedDate(diaryResponse.id, date)
+                                            }
                                             Toast.makeText(context, "기록 저장 성공", Toast.LENGTH_SHORT).show()
                                             onSave()
                                         } else {

--- a/app/src/main/java/com/example/baba/ui/home/CreateScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateScreen.kt
@@ -36,17 +36,17 @@ import java.time.format.DateTimeFormatter
 fun CreateScreen(
     selectedDate: LocalDate,
     title: String,
-    rating: Float,
+    rating: Double,
+    photo: Uri?,  // 단일 사진
     onBack: () -> Unit,
     onTitleChange: (String) -> Unit,
-    onRatingChange: (Float) -> Unit,
+    onRatingChange: (Double) -> Unit,
+    onPhotoChange: (Uri?) -> Unit,  // 사진 변경 콜백
     onNext: () -> Unit
 ) {
-    // 이미지 첨부 상태만 로컬로 관리합니다
-    var imageUri by remember { mutableStateOf<Uri?>(null) }
     val pickImageLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.GetContent()
-    ) { uri -> uri?.let { imageUri = it } }
+    ) { uri -> onPhotoChange(uri) }
 
     // 별점용 상수
     val starCount     = 5
@@ -62,9 +62,9 @@ fun CreateScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,      // ← 여기를 ArrowBack 으로
+                            imageVector = Icons.Filled.ArrowBack,
                             contentDescription = "뒤로",
-                            modifier = Modifier.size(24.dp)            // 사이즈 지정은 Modifier 에서
+                            modifier = Modifier.size(24.dp)
                         )
                     }
                 },
@@ -95,7 +95,7 @@ fun CreateScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            // 날짜 표시 (원하시면 추가)
+            // 날짜 표시
             Text(
                 text = selectedDate.format(DateTimeFormatter.ofPattern("M월 d일", Locale.getDefault())),
                 fontSize = 14.sp,
@@ -122,9 +122,9 @@ fun CreateScreen(
                     shape = RoundedCornerShape(12.dp),
                     elevation = CardDefaults.cardElevation(4.dp)
                 ) {
-                    if (imageUri != null) {
+                    if (photo != null) {
                         AsyncImage(
-                            model = imageUri,
+                            model = photo,
                             contentDescription = "첨부된 이미지",
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize()
@@ -175,8 +175,8 @@ fun CreateScreen(
                                 val block = starSizePx + starSpacePx
                                 val idx = (offset.x / block).toInt().coerceIn(0, starCount - 1)
                                 val within = offset.x % block
-                                val newRating = idx + if (within > starSizePx / 2) 1f else 0.5f
-                                onRatingChange(newRating.coerceIn(0f, starCount.toFloat()))
+                                val newRating = idx + if (within > starSizePx / 2) 1.0 else 0.5
+                                onRatingChange(newRating.coerceIn(0.0, starCount.toDouble()))
                             }
                         }
                 ) {
@@ -187,8 +187,8 @@ fun CreateScreen(
                     ) {
                         for (i in 0 until starCount) {
                             val icon = when {
-                                rating >= i + 1f    -> Icons.Filled.Star
-                                rating >= i + 0.5f -> Icons.Filled.StarHalf
+                                rating >= i + 1.0    -> Icons.Filled.Star
+                                rating >= i + 0.5 -> Icons.Filled.StarHalf
                                 else               -> Icons.Outlined.StarBorder
                             }
                             Icon(
@@ -208,17 +208,15 @@ fun CreateScreen(
 @Preview(showBackground = true)
 @Composable
 fun PreviewCreateScreen() {
-    // 예제용: 날짜, 람다만 더미로 전달
     CreateScreen(
         selectedDate   = LocalDate.now(),
         title          = "",
-        rating         = 2.5f,
+        rating         = 2.5,
+        photo          = null,
         onBack         = {},
         onTitleChange  = {},
         onRatingChange = {},
+        onPhotoChange  = {},
         onNext         = {}
     )
 }
-
-
-

--- a/app/src/main/java/com/example/baba/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -23,9 +24,27 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.baba.R
+import com.example.baba.data.network.RetrofitInstance
+import com.example.baba.data.record.DiaryResponse
 import com.example.baba.ui.theme.TextBlack
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import android.graphics.BitmapFactory
+import android.util.Base64
+import androidx.compose.ui.graphics.ImageBitmap
+import com.example.baba.data.record.WatchedDateManager
+import java.time.LocalDateTime
+
+fun rememberBase64ImageBitmap(base64String: String?): ImageBitmap? {
+    return try {
+        if (base64String.isNullOrEmpty()) return null
+        val imageBytes = Base64.decode(base64String, Base64.DEFAULT)
+        val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+        bitmap?.asImageBitmap()
+    } catch (e: Exception) {
+        null
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -38,13 +57,38 @@ fun HomeScreen() {
     var showCategorySheet by remember { mutableStateOf(false) }
     var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
 
-    val recordMap = if (currentMonth.year == today.year && currentMonth.monthValue == today.monthValue) {
-        mapOf(
-            4 to R.drawable.sample_movie,
-            8 to R.drawable.sample_theater,
-            12 to R.drawable.sample_movie2
-        )
-    } else emptyMap()
+    val diaries = remember { mutableStateListOf<DiaryResponse>() }
+
+    LaunchedEffect(Unit) {
+        WatchedDateManager.initialize(context)
+    }
+
+    // 기록 데이터 불러오기
+    LaunchedEffect(currentMonth) {
+        try {
+            val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId = 1L)
+            if (response.isSuccessful) {
+                diaries.clear()
+                diaries.addAll(response.body() ?: emptyList())
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    // 관람 날짜 기준으로 기록 매핑
+    val recordMap = diaries.mapNotNull { diary ->
+        val watchedDate = WatchedDateManager.getWatchedDate(diary.id)
+            ?: LocalDateTime.parse(diary.createdDate, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                .toLocalDate()
+
+        if (watchedDate.year == currentMonth.year && watchedDate.month == currentMonth.month) {
+            watchedDate.dayOfMonth to Triple(true, diary.image, diary.category)
+        } else {
+            null
+        }
+    }.toMap()
+
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -138,7 +182,10 @@ fun HomeScreen() {
                     val day = idx + 1
                     val date = currentMonth.withDayOfMonth(day)
                     val isToday = date == today
-                    val hasRecord = recordMap.containsKey(day)
+                    val recordInfo = recordMap[day]
+                    val hasRecord = recordInfo?.first ?: false
+                    val base64Image = recordInfo?.second
+                    val category = recordInfo?.third
 
                     Box(
                         modifier = Modifier
@@ -151,25 +198,8 @@ fun HomeScreen() {
                         contentAlignment = Alignment.Center
                     ) {
                         when {
-                            hasRecord -> {
-                                Image(
-                                    painter = painterResource(id = recordMap[day]!!),
-                                    contentDescription = "기록 이미지",
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .clip(MaterialTheme.shapes.small)
-                                )
-                                Text(
-                                    text = day.toString(),
-                                    fontSize = 12.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color.White,
-                                    modifier = Modifier
-                                        .align(Alignment.TopCenter)
-                                        .padding(top = 4.dp)
-                                )
-                            }
                             isToday -> {
+                                // 오늘 날짜 표시
                                 Box(
                                     modifier = Modifier
                                         .fillMaxSize()
@@ -193,7 +223,43 @@ fun HomeScreen() {
                                     }
                                 }
                             }
+                            hasRecord && base64Image != null -> {
+                                // 기록 있음 + 사진 있음: 사진만 표시
+                                val imageBitmap = rememberBase64ImageBitmap(base64Image)
+                                if (imageBitmap != null) {
+                                    Image(
+                                        bitmap = imageBitmap,
+                                        contentDescription = "기록 이미지",
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clip(MaterialTheme.shapes.small)
+                                    )
+                                }
+                            }
+                            hasRecord && base64Image == null -> {
+                                // 기록 있음 + 사진 없음: 회색 사각형 + 카테고리 아이콘
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(Color.LightGray, shape = MaterialTheme.shapes.small),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Image(
+                                        painter = painterResource(
+                                            id = when (category) {
+                                                "BOOK" -> R.drawable.recommend_book
+                                                "MOVIE" -> R.drawable.recommend_movie
+                                                "PERFORMANCE" -> R.drawable.recommend_show
+                                                else -> R.drawable.ic_add
+                                            }
+                                        ),
+                                        contentDescription = "카테고리 아이콘",
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
                             else -> {
+                                // 기록 없음: 날짜만 표시
                                 Text(
                                     text = day.toString(),
                                     fontSize = 12.sp,

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.baba.R
+import com.example.baba.data.network.RetrofitInstance
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,14 +36,34 @@ fun MyRecordListScreen(category: String) {
     var selected by rememberSaveable { mutableStateOf(initialIndex) }
     var isGridView by rememberSaveable { mutableStateOf(false) }
 
-    val records = listOf(
-        RecordData("하데스타운", "공연", "4.5", "2025.07.09.", "추천해요", R.drawable.ic_launcher_background),
-        RecordData("모순", "도서", "5.0", "2025.06.29.", "꼭 읽어야 할책", R.drawable.ic_nav_record),
-        RecordData("쥬라기 월드: 새로운 시작", "공연", "3.0", "2025.07.09.", "", R.drawable.recommend_book),
-        RecordData("8월의 크리스마스", "영화", "4.0", "2025.07.05.", "", R.drawable.recommend_show),
-        RecordData("디어 에반 핸슨", "영화", "4.7", "2025.07.01.", "", R.drawable.ic_nav_friend),
-        RecordData("이웃집 토토로", "영화", "4.8", "2025.06.25.", "", R.drawable.main_logo),
-    )
+    var records by remember { mutableStateOf<List<RecordData>>(emptyList()) }
+
+    LaunchedEffect(Unit) {
+        try {
+            val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId = 1L) // 사용자 ID는 필요 시 변경
+            if (response.isSuccessful) {
+                val diaries = response.body() ?: emptyList()
+                records = diaries.map {
+                    RecordData(
+                        title = it.title,
+                        category = when (it.category) {
+                            "BOOK" -> "도서"
+                            "MOVIE" -> "영화"
+                            "PERFORMANCE" -> "공연"
+                            else -> "기타"
+                        },
+                        rating = "4.0", // 백엔드 데이터 필요
+                        date = it.createdDate.split(" ")[0],
+                        comment = it.content,
+                        imageRes = R.drawable.ic_nav_record // 백엔드 데이터 필요
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
 
     val filteredRecords = if (selected == 0) records else records.filter { it.category == categoryName[selected] }
 

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
@@ -1,5 +1,7 @@
 package com.example.baba.ui.record
 
+import android.graphics.BitmapFactory
+import android.util.Base64
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -7,11 +9,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
-import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -20,13 +20,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.baba.R
 import com.example.baba.data.network.RetrofitInstance
+import com.example.baba.data.record.WatchedDateManager
+import com.example.baba.ui.theme.CoolGray500
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,14 +45,17 @@ fun MyRecordListScreen(category: String) {
     var isGridView by rememberSaveable { mutableStateOf(false) }
 
     var records by remember { mutableStateOf<List<RecordData>>(emptyList()) }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
+        WatchedDateManager.initialize(context)
         try {
             val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId = 1L) // 사용자 ID는 필요 시 변경
             if (response.isSuccessful) {
                 val diaries = response.body() ?: emptyList()
                 records = diaries.map {
                     RecordData(
+                        id = it.id,
                         title = it.title,
                         category = when (it.category) {
                             "BOOK" -> "도서"
@@ -52,10 +63,12 @@ fun MyRecordListScreen(category: String) {
                             "PERFORMANCE" -> "공연"
                             else -> "기타"
                         },
-                        rating = "4.0", // 백엔드 데이터 필요
-                        date = it.createdDate.split(" ")[0],
+                        rating = it.rating.toString(),
+                        date = WatchedDateManager.getWatchedDate(it.id)
+                            ?.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                            ?: it.createdDate.split(" ")[0],
                         comment = it.content,
-                        imageRes = R.drawable.ic_nav_record // 백엔드 데이터 필요
+                        image = it.image
                     )
                 }
             }
@@ -63,7 +76,6 @@ fun MyRecordListScreen(category: String) {
             e.printStackTrace()
         }
     }
-
 
     val filteredRecords = if (selected == 0) records else records.filter { it.category == categoryName[selected] }
 
@@ -127,7 +139,7 @@ fun MyRecordListScreen(category: String) {
             Spacer(modifier = Modifier.height(16.dp))
 
             if (isGridView) {
-                // 🔲 Grid View
+                // Grid View
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(3),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -136,9 +148,10 @@ fun MyRecordListScreen(category: String) {
                 ) {
                     items(filteredRecords.size) { index ->
                         val record = filteredRecords[index]
-                        Image(
-                            painter = painterResource(id = record.imageRes),
-                            contentDescription = record.title,
+                        GridImageItem(
+                            imageBase64 = record.image,
+                            title = record.title,
+                            category = record.category,  // 카테고리 전달
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(0.7f)
@@ -147,7 +160,7 @@ fun MyRecordListScreen(category: String) {
                     }
                 }
             } else {
-                // 📃 List View
+                // List View
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                     modifier = Modifier.fillMaxSize()
@@ -155,12 +168,13 @@ fun MyRecordListScreen(category: String) {
                     items(filteredRecords.size) { index ->
                         val record = filteredRecords[index]
                         RecordItem(
+                            id = record.id,
                             title = record.title,
                             category = record.category,
                             rating = record.rating,
                             date = record.date,
                             comment = record.comment,
-                            imageRes = record.imageRes
+                            imageBase64 = record.image
                         )
                     }
                 }
@@ -169,37 +183,148 @@ fun MyRecordListScreen(category: String) {
     }
 }
 
+@Composable
+fun rememberBase64Image(base64String: String?): androidx.compose.ui.graphics.ImageBitmap? {
+    return remember(base64String) {
+        try {
+            if (base64String.isNullOrEmpty()) return@remember null
+            val imageBytes = Base64.decode(base64String, Base64.DEFAULT)
+            val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+            bitmap?.asImageBitmap()
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+// Grid View용 이미지 아이템
+@Composable
+fun GridImageItem(
+    imageBase64: String?,
+    title: String,
+    category: String,
+    modifier: Modifier = Modifier
+) {
+    val imageBitmap = rememberBase64Image(imageBase64)
+
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.LightGray)
+    ) {
+        if (imageBitmap != null) {
+            // 이미지가 있을 때는 이미지만 표시
+            Image(
+                bitmap = imageBitmap,
+                contentDescription = "Thumbnail",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            // 카테고리 아이콘
+            Image(
+                painter = painterResource(
+                    id = when (category) {
+                        "도서" -> R.drawable.recommend_book
+                        "영화" -> R.drawable.recommend_movie
+                        "공연" -> R.drawable.recommend_show
+                        else -> R.drawable.ic_add
+                    }
+                ),
+                contentDescription = "카테고리 아이콘",
+                modifier = Modifier
+                    .size(45.dp)
+                    .align(Alignment.Center)
+            )
+
+            // 제목
+            Text(
+                text = title,
+                color = CoolGray500,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .offset(y = (-16).dp)
+                    .padding(horizontal = 4.dp)
+            )
+        }
+    }
+}
+
 data class RecordData(
+    val id: Long,
     val title: String,
     val category: String,
     val rating: String,
     val date: String,
     val comment: String,
-    val imageRes: Int
+    val image: String?
 )
 
 @Composable
 fun RecordItem(
+    id: Long,
     title: String,
     category: String,
     rating: String,
     date: String,
     comment: String,
-    imageRes: Int
+    imageBase64: String?
 ) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        WatchedDateManager.initialize(context)
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable { }
     ) {
-        Image(
-            painter = painterResource(id = imageRes),
-            contentDescription = "Thumbnail",
+        val imageBitmap = rememberBase64Image(imageBase64)
+
+        Box(
             modifier = Modifier
                 .size(72.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(Color.LightGray)
-        )
+        ) {
+            if (imageBitmap != null) {
+                Image(
+                    bitmap = imageBitmap,
+                    contentDescription = "Thumbnail",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.LightGray),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = painterResource(
+                            id = when (category) {
+                                "도서" -> R.drawable.recommend_book
+                                "영화" -> R.drawable.recommend_movie
+                                "공연" -> R.drawable.recommend_show
+                                else -> R.drawable.ic_add
+                            }
+                        ),
+                        contentDescription = "카테고리 아이콘",
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+        }
 
         Spacer(modifier = Modifier.width(12.dp))
 
@@ -221,7 +346,13 @@ fun RecordItem(
                 )
                 Text(text = rating, fontSize = 12.sp)
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = date, fontSize = 12.sp)
+
+                val watchedDate = WatchedDateManager.getWatchedDate(id)
+                    ?.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                    ?: date
+
+                Text(text = watchedDate, fontSize = 12.sp)
+
             }
 
             if (comment.isNotBlank()) {

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
@@ -1,5 +1,6 @@
 package com.example.baba.ui.record
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -18,11 +19,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavHost
-import androidx.navigation.compose.rememberNavController
-import androidx.compose.foundation.layout.Spacer as Spacer1
+import coil.compose.AsyncImage
+import com.example.baba.data.network.RetrofitInstance
+import com.example.baba.data.record.DiaryResponse
+import androidx.compose.foundation.layout.Spacer
 
 //화면 출력
+@Preview(showBackground = true)
 @Composable
 fun MyRecordScreen() {
     var showRecordList by remember { mutableStateOf(false) }
@@ -44,6 +47,8 @@ fun MyRecordScreen() {
 fun MyRecordMainContent(
     onCategoryClick: (String) -> Unit
 ) {
+    var categoryCounts by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+
     Scaffold(
         topBar = { TopBar() }
     ) { innerPadding ->
@@ -56,9 +61,11 @@ fun MyRecordMainContent(
             item { ProfileCard() }
             item { TimeFilterTabs() }
             item {
-                CategoryTabs(onCategoryClick) // 클릭 콜백 전달
+                CategoryTabs(onCategoryClick, categoryCounts)
             }
-            item { RecordList() }
+            item {
+                RecordList(onCountReady = { counts -> categoryCounts = counts })
+            }
         }
     }
 }
@@ -77,7 +84,7 @@ fun TopBar() {
         Text("칠공주's", fontSize = 20.sp, fontWeight = FontWeight.Bold)
         Row {
             Icon(Icons.Default.Search, contentDescription = "Search")
-            Spacer1(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(16.dp))
             Icon(Icons.Default.Settings, contentDescription = "Settings")
         }
     }
@@ -111,7 +118,7 @@ fun ProfileCard() {
                         .testTag("profile_image")
                 )
 
-                Spacer1(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
                     text = "칠공주",
@@ -119,14 +126,14 @@ fun ProfileCard() {
                     fontSize = 16.sp,
                     modifier = Modifier.testTag("name")
                 )
-                Spacer1(modifier = Modifier.height(2.dp))
+                Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = "안녕하세요 칠공주의 공간입니다.",
                     fontSize = 13.sp,
                     modifier = Modifier.testTag("coment")
                 )
 
-                Spacer1(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
                 Button(
                     onClick = { /* TODO */ },
@@ -224,14 +231,16 @@ fun TimeFilterTabs() {
         }
     }
 
-    Spacer1(modifier = Modifier.height(8.dp)) // 하단 여백
+    Spacer(modifier = Modifier.height(8.dp)) // 하단 여백
 }
 
 // 4. 기록 분류
 @Composable
-fun CategoryTabs(onCategoryClick: (String) -> Unit) {
+fun CategoryTabs(
+    onCategoryClick: (String) -> Unit,
+    categoryCounts: Map<String, Int> = mapOf("전체" to 0, "도서" to 0, "영화" to 0, "공연" to 0)
+) {
     val categoryName = listOf("전체", "도서", "영화", "공연")
-    val categoryNum = listOf("6", "1", "3", "2")
     var selected by remember { mutableStateOf(0) }
 
     Row(
@@ -241,6 +250,7 @@ fun CategoryTabs(onCategoryClick: (String) -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         categoryName.forEachIndexed { i, name ->
+            val count = categoryCounts[name] ?: 0
             Box(
                 modifier = Modifier
                     .weight(1f)
@@ -248,13 +258,13 @@ fun CategoryTabs(onCategoryClick: (String) -> Unit) {
                     .background(Color.LightGray)
                     .clickable {
                         selected = i
-                        onCategoryClick(name) // ✅ 여기서 호출
+                        onCategoryClick(name)
                     }
                     .padding(vertical = 12.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = "$name ${categoryNum[i]}",
+                    text = "$name $count",
                     color = Color.Black,
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Medium
@@ -264,75 +274,107 @@ fun CategoryTabs(onCategoryClick: (String) -> Unit) {
     }
 }
 
+
 // 5. 기록 리스트
 @Composable
-fun RecordList() {
+fun RecordList(onCountReady: (Map<String, Int>) -> Unit = {}) {
+    var diaries by remember { mutableStateOf<List<DiaryResponse>>(emptyList()) }
+
+    LaunchedEffect(Unit) {
+        try {
+            val userId = 1L
+            val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId)
+            if (response.isSuccessful) {
+                val data = response.body() ?: emptyList()
+                diaries = data
+
+                // 카테고리별 개수 계산
+                val counts = mapOf(
+                    "전체" to data.size,
+                    "도서" to data.count { it.category == "BOOK" },
+                    "영화" to data.count { it.category == "MOVIE" },
+                    "공연" to data.count { it.category == "PERFORMANCE" },
+                )
+                onCountReady(counts)
+            }
+        } catch (e: Exception) {
+            Log.e("RecordList", "일기 불러오기 실패: ${e.message}")
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
             .padding(top = 4.dp)
     ) {
+        Text("기록", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = Color.Black)
 
-        Text(
-            text = "기록",
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Bold,
-            color = Color.Black
-        )
+        diaries.forEach { diary ->
+            DiaryCard(diary)
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
 
-        // 🔄 Card → Button 으로 변경
-        Button(
-            onClick = { /* TODO: 기록 상세 보기 등 */ },
-            modifier = Modifier.fillMaxWidth(),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color(0xFFF5F5F5), // 카드처럼 연한 회색 배경
-                contentColor = Color.Black
-            ),
-            contentPadding = PaddingValues(16.dp),
-            shape = RoundedCornerShape(8.dp),
-            elevation = ButtonDefaults.buttonElevation(defaultElevation = 2.dp)
+
+@Composable
+fun DiaryCard(diary: DiaryResponse) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(12.dp)
+                .fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            // 썸네일 이미지 (임시)
+            AsyncImage(
+                model = "https://via.placeholder.com/80", // 썸네일 이미지 URL 또는 diary.imageUrl
+                contentDescription = "썸네일",
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.LightGray)
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // 텍스트 정보
+            Column(
+                verticalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxHeight()
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(64.dp)
-                        .background(Color.LightGray)
-                ) {
-                    Icon(
-                        Icons.Default.DateRange,
-                        contentDescription = null,
-                        modifier = Modifier.align(Alignment.Center)
-                    )
-                }
-
-                Spacer1(modifier = Modifier.width(12.dp))
-
-                Column {
-                    Text("하데스타운", fontWeight = FontWeight.Bold)
-                    Text("공연", fontSize = 12.sp, color = Color.Gray)
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            Icons.Default.Done,
-                            contentDescription = null,
-                            tint = Color(0xFF1E88E5),
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Text("4.5", fontSize = 12.sp)
-                        Spacer1(modifier = Modifier.width(8.dp))
-                        Text("2025.07.09.", fontSize = 12.sp)
-                    }
-
-                    Text("추천해요", fontSize = 12.sp)
-                }
+                Text(
+                    text = diary.title,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 15.sp,
+                    maxLines = 1
+                )
+                Text(
+                    text = diary.categoryLabel,
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+                Text(
+                    text = diary.createdDate.split(" ")[0],  // 날짜만
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+                Text(
+                    text = diary.content,
+                    fontSize = 12.sp,
+                    color = Color.DarkGray,
+                    maxLines = 1
+                )
             }
         }
-
-        Spacer1(modifier = Modifier.height(16.dp)) // 여유 여백
     }
 }
 

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
@@ -1,6 +1,9 @@
 package com.example.baba.ui.record
 
+import android.graphics.BitmapFactory
+import android.util.Base64
 import android.util.Log
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -14,15 +17,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
 import com.example.baba.data.network.RetrofitInstance
 import com.example.baba.data.record.DiaryResponse
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import com.example.baba.R
+import com.example.baba.data.record.WatchedDateManager
+import java.time.format.DateTimeFormatter
 
 //화면 출력
 @Preview(showBackground = true)
@@ -69,7 +78,6 @@ fun MyRecordMainContent(
         }
     }
 }
-
 
 // 1. 탑 바 구현
 @Composable
@@ -274,11 +282,12 @@ fun CategoryTabs(
     }
 }
 
-
 // 5. 기록 리스트
 @Composable
 fun RecordList(onCountReady: (Map<String, Int>) -> Unit = {}) {
     var diaries by remember { mutableStateOf<List<DiaryResponse>>(emptyList()) }
+
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         try {
@@ -317,9 +326,30 @@ fun RecordList(onCountReady: (Map<String, Int>) -> Unit = {}) {
     }
 }
 
+// Base64 문자열을 ImageBitmap으로 변환하는 함수
+@Composable
+fun rememberBase64ImageBitmap(base64String: String?): androidx.compose.ui.graphics.ImageBitmap? {
+    return remember(base64String) {
+        try {
+            if (base64String.isNullOrEmpty()) return@remember null
+            val imageBytes = Base64.decode(base64String, Base64.DEFAULT)
+            val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+            bitmap?.asImageBitmap()
+        } catch (e: Exception) {
+            Log.e("Base64Image", "이미지 변환 실패: ${e.message}")
+            null
+        }
+    }
+}
 
 @Composable
 fun DiaryCard(diary: DiaryResponse) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        WatchedDateManager.initialize(context)
+    }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -334,15 +364,45 @@ fun DiaryCard(diary: DiaryResponse) {
                 .fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // 썸네일 이미지 (임시)
-            AsyncImage(
-                model = "https://via.placeholder.com/80", // 썸네일 이미지 URL 또는 diary.imageUrl
-                contentDescription = "썸네일",
+            // Base64 이미지 처리
+            val imageBitmap = rememberBase64ImageBitmap(diary.image)
+
+            Box(
                 modifier = Modifier
                     .size(64.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(Color.LightGray)
-            )
+            ) {
+                if (imageBitmap != null) {
+                    Image(
+                        bitmap = imageBitmap,
+                        contentDescription = "썸네일",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    // 이미지가 없을 때 플레이스홀더
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.LightGray),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Image(
+                            painter = painterResource(
+                                id = when (diary.category) {
+                                    "BOOK" -> R.drawable.recommend_book
+                                    "MOVIE" -> R.drawable.recommend_movie
+                                    "PERFORMANCE" -> R.drawable.recommend_show
+                                    else -> R.drawable.ic_add
+                                }
+                            ),
+                            contentDescription = "카테고리 아이콘",
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.width(12.dp))
 
@@ -362,11 +422,17 @@ fun DiaryCard(diary: DiaryResponse) {
                     fontSize = 12.sp,
                     color = Color.Gray
                 )
+
+                val watchedDate = WatchedDateManager.getWatchedDate(diary.id)
+                    ?.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                    ?: diary.createdDate.split(" ")[0]
+
                 Text(
-                    text = diary.createdDate.split(" ")[0],  // 날짜만
+                    text = watchedDate,
                     fontSize = 12.sp,
                     color = Color.Gray
                 )
+
                 Text(
                     text = diary.content,
                     fontSize = 12.sp,
@@ -377,7 +443,6 @@ fun DiaryCard(diary: DiaryResponse) {
         }
     }
 }
-
 
 //@Preview(showBackground = true, name = "MyRecord Preview")
 @Composable


### PR DESCRIPTION
# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
문화생활 기록 전체 조회 API 연동

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #27 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 문화생활 기록 전체 조회 API 연동
- WatchedDateManager 구현 (SharedPreferences 기반)
- 이미지 없는 기록에 대한 카테고리 아이콘 표시 기능 구현
- 그리드 뷰에서 이미지 없는 항목에 대한 제목 표시 기능 구현

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- WatchedDateManager는 임시 구현으로 SharedPreferences를 사용하여 관람 날짜를 관리
- 추후 백엔드에서 watchedAt 필드를 응답에 포함하면 해당 로직을 제거하고 서버 데이터를 사용하도록 수정 예정