### PR TITLE
[feat/#50] 문화생활 기록 삭제 API 연동

### DIFF
--- a/app/src/main/java/com/example/baba/MainActivity.kt
+++ b/app/src/main/java/com/example/baba/MainActivity.kt
@@ -143,30 +143,8 @@ fun RecordNavigation() {
                 ?.get<Record>("record")
 
             record?.let {
-                val actualWatchedDate = WatchedDateManager.getWatchedDate(record.id)
-                    ?: try {
-                        when {
-                            it.date.contains(".") -> {
-                                val dateStr = it.date.replace(".", "-").removeSuffix("-")
-                                LocalDate.parse(dateStr)
-                            }
-                            it.date.contains("-") -> {
-                                LocalDate.parse(it.date)
-                            }
-                            else -> LocalDate.now()
-                        }
-                    } catch (e: Exception) {
-                        LocalDate.now()
-                    }
-
                 RecordDetailScreen(
-                    title = it.title,
-                    date = actualWatchedDate,
-                    rating = it.rating,
-                    content = it.content,
-                    isPublic = it.isPublic,
-                    category = it.category,
-                    photoUri = it.photoUri,
+                    record = it,
                     navController = recordNavController
                 )
             }

--- a/app/src/main/java/com/example/baba/data/member/MemberModels.kt
+++ b/app/src/main/java/com/example/baba/data/member/MemberModels.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 // 회원 정보 조회 응답 DTO
 data class MemberInfoResponse(
+    @SerializedName("id") val id: Long,  // ← id 필드 추가
     @SerializedName("username") val username: String,
     @SerializedName("name") val name: String,
     @SerializedName("profileImageUrl") val profileImageUrl: String?,

--- a/app/src/main/java/com/example/baba/data/network/SessionManager.kt
+++ b/app/src/main/java/com/example/baba/data/network/SessionManager.kt
@@ -2,4 +2,5 @@ package com.example.baba.data.network
 
 object SessionManager {
     var userId: Long? = null
+    var needsRefresh: Boolean = false
 }

--- a/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
+++ b/app/src/main/java/com/example/baba/data/record/DiaryApi.kt
@@ -19,4 +19,10 @@ interface DiaryApi {
 
     @GET("diaries/me")
     suspend fun getAllMyDiaries(@Query("id") userId: Long): Response<List<DiaryResponse>>
+
+    @DELETE("diaries/{diary_id}")
+    suspend fun deleteDiary(
+        @Path("diary_id") diaryId: Long,
+        @Query("memberId") memberId: Long
+    ): Response<String>
 }

--- a/app/src/main/java/com/example/baba/ui/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/auth/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.example.baba.ui.auth
 
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -124,8 +125,9 @@ fun LoginScreen(
                                     "user1" -> 1L
                                     "user2" -> 2L
                                     "admin" -> 99L
-                                    else -> -1L // 임시 userId
+                                    else -> 1L
                                 }
+                                Log.d("Login", "SessionManager.userId 설정됨: ${SessionManager.userId}")
                                 onLoginSuccess()
                             } else {
                                 Toast.makeText(context, message, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/CreateDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.example.baba.data.network.RetrofitInstance
+import com.example.baba.data.network.SessionManager
 import com.example.baba.data.record.WatchedDateManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -110,6 +111,8 @@ fun CreateDetailScreen(
                         onClick = {
                             CoroutineScope(Dispatchers.IO).launch {
                                 try {
+                                    Log.d("CreateDetail", "현재 userId: $userId")
+
                                     val imagePart = photo?.let { uriToMultipart(it) }
 
                                     val response = RetrofitInstance.diaryApi.createDiary(
@@ -127,6 +130,7 @@ fun CreateDetailScreen(
                                             response.body()?.let { diaryResponse ->
                                                 WatchedDateManager.setWatchedDate(diaryResponse.id, date)
                                             }
+                                            SessionManager.needsRefresh = true
                                             Toast.makeText(context, "기록 저장 성공", Toast.LENGTH_SHORT).show()
                                             onSave()
                                         } else {

--- a/app/src/main/java/com/example/baba/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/home/HomeScreen.kt
@@ -36,7 +36,9 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.baba.data.member.MemberInfoResponse
+import com.example.baba.data.network.SessionManager
 import com.example.baba.data.record.WatchedDateManager
+import kotlinx.coroutines.delay
 import java.time.LocalDateTime
 
 fun rememberBase64ImageBitmap(base64String: String?): ImageBitmap? {
@@ -72,10 +74,27 @@ fun HomeScreen(navController: NavController? = null) {
 
     // 새로고침 처리
     LaunchedEffect(Unit) {
+        if (SessionManager.needsRefresh) {
+            refreshKey.value++
+            SessionManager.needsRefresh = false
+        }
+
         savedStateHandle?.get<Boolean>("refresh")?.let { isRefresh ->
             if (isRefresh) {
                 refreshKey.value++
                 savedStateHandle.remove<Boolean>("refresh")
+            }
+        }
+    }
+
+    // 주기적으로 새로고침 플래그 체크
+    LaunchedEffect(refreshKey.value) {
+        while (true) {
+            delay(500) // 0.5초마다 체크
+            if (SessionManager.needsRefresh) {
+                refreshKey.value++
+                SessionManager.needsRefresh = false
+                break // 새로고침 후 루프 종료
             }
         }
     }

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordList.kt
@@ -57,28 +57,34 @@ fun MyRecordListScreen(category: String, navController: NavController) {
             val memberResponse = RetrofitInstance.memberApi.getMyInfo()
             if (memberResponse.isSuccessful) {
                 memberName = memberResponse.body()?.name ?: ""
-            }
 
-            val diaryResponse = RetrofitInstance.diaryApi.getAllMyDiaries(userId = 1L)
-            if (diaryResponse.isSuccessful) {
-                val diaries = diaryResponse.body() ?: emptyList()
-                records = diaries.map {
-                    RecordData(
-                        id = it.id,
-                        title = it.title,
-                        category = when (it.category) {
-                            "BOOK" -> "도서"
-                            "MOVIE" -> "영화"
-                            "PERFORMANCE" -> "공연"
-                            else -> "기타"
-                        },
-                        rating = it.rating.toString(),
-                        date = WatchedDateManager.getWatchedDate(it.id)
-                            ?.format(DateTimeFormatter.ISO_LOCAL_DATE)
-                            ?: it.createdDate.split(" ")[0],
-                        comment = it.content,
-                        image = it.image
-                    )
+                // 현재 사용자 ID 가져오기
+                val currentUserId = memberResponse.body()?.id
+                println("현재 사용자 ID: $currentUserId")
+
+                if (currentUserId != null) {
+                    val diaryResponse = RetrofitInstance.diaryApi.getAllMyDiaries(userId = currentUserId)
+                    if (diaryResponse.isSuccessful) {
+                        val diaries = diaryResponse.body() ?: emptyList()
+                        records = diaries.map {
+                            RecordData(
+                                id = it.id,
+                                title = it.title,
+                                category = when (it.category) {
+                                    "BOOK" -> "도서"
+                                    "MOVIE" -> "영화"
+                                    "PERFORMANCE" -> "공연"
+                                    else -> "기타"
+                                },
+                                rating = it.rating.toString(),
+                                date = WatchedDateManager.getWatchedDate(it.id)
+                                    ?.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                                    ?: it.createdDate.split(" ")[0],
+                                comment = it.content,
+                                image = it.image
+                            )
+                        }
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
@@ -404,30 +404,44 @@ fun RecordList(
     onCountReady: (Map<String, Int>) -> Unit = {},
     navController: NavController
 ) {
-
     var diaries by remember { mutableStateOf<List<DiaryResponse>>(emptyList()) }
-
+    var currentUserId by remember { mutableStateOf<Long?>(null) }
     val context = LocalContext.current
 
+    // 현재 사용자 ID 가져오기
     LaunchedEffect(Unit) {
         try {
-            val userId = 1L
-            val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId)
-            if (response.isSuccessful) {
-                val data = response.body() ?: emptyList()
-                diaries = data
-
-                // 카테고리별 개수 계산
-                val counts = mapOf(
-                    "전체" to data.size,
-                    "도서" to data.count { it.category == "BOOK" },
-                    "영화" to data.count { it.category == "MOVIE" },
-                    "공연" to data.count { it.category == "PERFORMANCE" },
-                )
-                onCountReady(counts)
+            val memberResponse = RetrofitInstance.memberApi.getMyInfo()
+            if (memberResponse.isSuccessful) {
+                currentUserId = memberResponse.body()?.id
+                println("현재 사용자 ID: $currentUserId")
             }
         } catch (e: Exception) {
-            Log.e("RecordList", "일기 불러오기 실패: ${e.message}")
+            Log.e("RecordList", "사용자 정보 조회 실패: ${e.message}")
+        }
+    }
+
+    // 사용자 ID를 가져온 후 다이어리 조회
+    LaunchedEffect(currentUserId) {
+        currentUserId?.let { userId ->
+            try {
+                val response = RetrofitInstance.diaryApi.getAllMyDiaries(userId)
+                if (response.isSuccessful) {
+                    val data = response.body() ?: emptyList()
+                    diaries = data
+
+                    // 카테고리별 개수 계산
+                    val counts = mapOf(
+                        "전체" to data.size,
+                        "도서" to data.count { it.category == "BOOK" },
+                        "영화" to data.count { it.category == "MOVIE" },
+                        "공연" to data.count { it.category == "PERFORMANCE" },
+                    )
+                    onCountReady(counts)
+                }
+            } catch (e: Exception) {
+                Log.e("RecordList", "일기 불러오기 실패: ${e.message}")
+            }
         }
     }
 
@@ -445,6 +459,7 @@ fun RecordList(
         }
     }
 }
+
 
 // Base64 문자열을 ImageBitmap으로 변환하는 함수
 @Composable

--- a/app/src/main/java/com/example/baba/ui/record/RecordDetailScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/record/RecordDetailScreen.kt
@@ -1,44 +1,127 @@
 package com.example.baba.ui.record
 
 import android.net.Uri
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
+import com.example.baba.data.network.RetrofitInstance
+import com.example.baba.data.network.SessionManager
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecordDetailScreen(
-    title: String,
-    date: LocalDate,
-    rating: Float,
-    content: String,
-    isPublic: Boolean,
-    category: String,
-    photoUri: Uri?,
+    record: Record,
     navController: NavController
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd. (E)")
+    val date = try {
+        LocalDate.parse(record.date)
+    } catch (e: Exception) {
+        LocalDate.now()
+    }
+
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var isDeleting by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    // 삭제 다이얼로그
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = {
+                Text(
+                    text = "기록 삭제",
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                Text(
+                    text = "정말로 이 기록을 삭제하시겠습니까?\n삭제된 기록은 복구할 수 없습니다.",
+                    textAlign = TextAlign.Center
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showDeleteDialog = false
+                        isDeleting = true
+                        coroutineScope.launch {
+                            try {
+                                val userId = SessionManager.userId
+                                if (userId == null || userId <= 0) {
+                                    println("사용자 ID가 없습니다. 다시 로그인해주세요.")
+                                    return@launch
+                                }
+
+                                Log.d("Delete", "삭제 요청: diaryId=${record.id}, memberId=$userId") // ← 로그 추가
+                                val response = RetrofitInstance.diaryApi.deleteDiary(
+                                    memberId = userId,
+                                    diaryId = record.id
+                                )
+                                Log.d("Delete", "삭제 응답: ${response.isSuccessful}, ${response.code()}") // ← 로그 추가
+                                if (response.isSuccessful) {
+                                    navController.popBackStack()
+                                } else {
+                                    Log.e("Delete", "삭제 실패: ${response.errorBody()?.string()}") // ← 로그 추가
+                                }
+                            } catch (e: Exception) {
+                                Log.e("Delete", "삭제 오류: ${e.message}", e) // ← 로그 추가
+                            } finally {
+                                isDeleting = false
+                            }
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Red
+                    ),
+                    enabled = !isDeleting
+                ) {
+                    if (isDeleting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = Color.White
+                        )
+                    } else {
+                        Text("삭제", color = Color.White)
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    enabled = !isDeleting
+                ) {
+                    Text("취소")
+                }
+            }
+        )
+    }
 
     Column(
         modifier = Modifier
@@ -46,28 +129,47 @@ fun RecordDetailScreen(
             .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 80.dp)
             .verticalScroll(rememberScrollState())
     ) {
-        // 상단 나가기 화살표
-        Icon(
-            imageVector = Icons.Default.ArrowBack,
-            contentDescription = "Back",
-            modifier = Modifier
-                .size(28.dp)
-                .clickable {
-                    navController.popBackStack() // MyRecordScreen으로 이동
-                }
-        )
+        // 상단 헤더 (뒤로가기 버튼과 삭제 버튼)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 뒤로가기 버튼
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                modifier = Modifier
+                    .size(28.dp)
+                    .clickable {
+                        navController.popBackStack()
+                    }
+            )
+
+            // 삭제 버튼
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "Delete",
+                tint = Color.Red,
+                modifier = Modifier
+                    .size(28.dp)
+                    .clickable {
+                        showDeleteDialog = true
+                    }
+            )
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // 공개 여부
         Text(
-            text = if (isPublic) "전체 공개" else "비공개",
+            text = if (record.isPublic) "전체 공개" else "비공개",
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.align(Alignment.Start)
         )
 
         // 이미지
-        photoUri?.let {
+        record.photoUri?.let {
             Image(
                 painter = rememberAsyncImagePainter(it),
                 contentDescription = null,
@@ -81,7 +183,7 @@ fun RecordDetailScreen(
 
         // 제목
         Text(
-            text = title,
+            text = record.title,
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(top = 20.dp)
@@ -89,7 +191,7 @@ fun RecordDetailScreen(
 
         // 카테고리
         Text(
-            text = category,
+            text = record.category,
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(top = 4.dp)
         )
@@ -107,12 +209,12 @@ fun RecordDetailScreen(
             modifier = Modifier.padding(top = 8.dp)
         ) {
             Icon(Icons.Default.Star, contentDescription = null)
-            Text("  $rating", fontSize = 14.sp)
+            Text("  ${record.rating}", fontSize = 14.sp)
         }
 
         // 내용
         Text(
-            text = content,
+            text = record.content,
             fontSize = 14.sp,
             modifier = Modifier.padding(top = 20.dp)
         )
@@ -121,7 +223,7 @@ fun RecordDetailScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 300.dp),
-            horizontalAlignment = Alignment.CenterHorizontally  // ✅ 전체 가운데 정렬
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
                 text = "You might also like",


### PR DESCRIPTION
# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
문화생활 기록 삭제 API 연동

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #50 

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 백엔드에서 `DiaryController의 diaryService.deleteDiary(diaryId, memberId);` 로 파라미터 순서 변경 필요
- 기록 삭제 시 외래키 제약조건으로 인해 백엔드 Diary 엔티티 수정 필요
`@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true) private List<Recommendation> recommendations;
`