### PR TITLE
[feat#67] 팔로워/팔로잉 리스트 화면 추가 구현

### DIFF
--- a/app/src/main/java/com/example/baba/data/friends/FriendsApi.kt
+++ b/app/src/main/java/com/example/baba/data/friends/FriendsApi.kt
@@ -1,11 +1,24 @@
 package com.example.baba.data.friends
 
+import com.example.baba.data.member.MemberInfoResponse
 import retrofit2.http.*
 
 interface FriendsApi {
    @GET("friends/following")
-   suspend fun getFollowingList(@Query("username") username: String): List<FriendResponse>
+   suspend fun getFollowingList(@Query("username") username: String): List<MemberInfoResponse>
 
    @GET("friends/follower")
-   suspend fun getFollowerList(@Query("username") username: String): List<FriendResponse>
+   suspend fun getFollowerList(@Query("username") username: String): List<MemberInfoResponse >
+
+   @POST("friends/request")
+   suspend fun followUser(
+      @Query("fromUsername") fromUsername: String,
+      @Query("toUsername") toUsername: String
+   ): retrofit2.Response<String>
+
+   @DELETE("friends/unfollow")
+   suspend fun unfollowUser(
+      @Query("fromUsername") fromUsername: String,
+      @Query("toUsername") toUsername: String
+   ): retrofit2.Response<String>
 }

--- a/app/src/main/java/com/example/baba/data/member/MemberModels.kt
+++ b/app/src/main/java/com/example/baba/data/member/MemberModels.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 // 회원 정보 조회 응답 DTO
 data class MemberInfoResponse(
-    @SerializedName("id") val id: Long,  // ← id 필드 추가
+    @SerializedName("id") val id: Long,
     @SerializedName("username") val username: String,
     @SerializedName("name") val name: String,
     @SerializedName("profileImageUrl") val profileImageUrl: String?,

--- a/app/src/main/java/com/example/baba/ui/friends/FollowScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/friends/FollowScreen.kt
@@ -19,11 +19,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.example.baba.R
-import com.example.baba.data.friends.FriendResponse
+import com.example.baba.data.member.MemberInfoResponse
 import com.example.baba.data.network.RetrofitInstance
 import com.example.baba.ui.theme.Blue1
-import com.example.baba.ui.theme.CoolGray500
-import kotlinx.coroutines.launch
 
 @Composable
 fun FollowScreen(
@@ -33,8 +31,8 @@ fun FollowScreen(
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
     var showProfileScreen by remember { mutableStateOf(false) }
-    var followingList by remember { mutableStateOf<List<FriendResponse>>(emptyList()) }
-    var followerList by remember { mutableStateOf<List<FriendResponse>>(emptyList()) }
+    var followingList by remember { mutableStateOf<List<MemberInfoResponse>>(emptyList()) }
+    var followerList by remember { mutableStateOf<List<MemberInfoResponse>>(emptyList()) }
     var isLoading by remember { mutableStateOf(false) }
     var currentUsername by remember { mutableStateOf("") }
     val coroutineScope = rememberCoroutineScope()
@@ -50,7 +48,6 @@ fun FollowScreen(
         }
     }
 
-
     // 탭 타이틀 동적 생성
     val tabTitles = listOf(
         "팔로잉 ${followingList.size}",
@@ -58,21 +55,19 @@ fun FollowScreen(
     )
 
     // API 호출
-    LaunchedEffect(selectedTabIndex, currentUsername) {
+    LaunchedEffect(currentUsername) {
         if (currentUsername.isNotEmpty()) {
-            coroutineScope.launch {
-                isLoading = true
-                try {
-                    if (selectedTabIndex == 0) {
-                        followingList = RetrofitInstance.friendsApi.getFollowingList(currentUsername)
-                    } else {
-                        followerList = RetrofitInstance.friendsApi.getFollowerList(currentUsername)
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                } finally {
-                    isLoading = false
-                }
+            isLoading = true
+            try {
+                val followingResponse = RetrofitInstance.friendsApi.getFollowingList(currentUsername)
+                followingList = followingResponse
+
+                val followerResponse = RetrofitInstance.friendsApi.getFollowerList(currentUsername)
+                followerList = followerResponse
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                isLoading = false
             }
         }
     }
@@ -135,9 +130,9 @@ fun FollowScreen(
                 }
             } else {
                 val list = if (selectedTabIndex == 0) followingList else followerList
-                items(list) { friend ->
+                items(list) { member ->
                     FriendListItem(
-                        friend = friend,
+                        member = member,
                         onProfileClick = { showProfileScreen = true }
                     )
                 }
@@ -165,7 +160,7 @@ fun FollowTopBar(
 
 @Composable
 fun FriendListItem(
-    friend: FriendResponse,
+    member: MemberInfoResponse,
     onProfileClick: () -> Unit
 ) {
     Row(
@@ -176,8 +171,8 @@ fun FriendListItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Image(
-            painter = if (friend.profileImageUrl != null) {
-                rememberAsyncImagePainter(friend.profileImageUrl)
+            painter = if (member.profileImageUrl != null) {
+                rememberAsyncImagePainter(member.profileImageUrl)
             } else {
                 painterResource(id = R.drawable.ic_default_profile)
             },
@@ -186,8 +181,16 @@ fun FriendListItem(
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column {
-            Text(friend.nickname, fontWeight = FontWeight.Medium)
-            Text(friend.username, fontSize = 12.sp, color = Color.Gray)
+            Text(
+                text = member.name,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp
+            )
+            Text(
+                text = member.username,
+                fontSize = 12.sp,
+                color = Color.Gray
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
+++ b/app/src/main/java/com/example/baba/ui/record/MyRecordScreen.kt
@@ -281,8 +281,9 @@ fun ProfileCard(
         memberInfo?.let { info ->
             coroutineScope.launch {
                 try {
-                    val followers = RetrofitInstance.friendsApi.getFollowerList(info.username)
-                    followerCount = followers.size
+                    val followerUsernames = RetrofitInstance.friendsApi.getFollowerList(info.username)
+                    followerCount = followerUsernames.size
+                    Log.d("ProfileCard", "팔로워: ${followerCount}")
                 } catch (e: Exception) {
                     Log.e("ProfileCard", "팔로워 수 조회 실패: ${e.message}")
                 }
@@ -299,12 +300,9 @@ fun ProfileCard(
         shape = RoundedCornerShape(12.dp)
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .height(250.dp)
+            modifier = Modifier.fillMaxSize()
         ) {
             if (memberInfo == null) {
-                // 로딩 상태
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
@@ -324,17 +322,14 @@ fun ProfileCard(
                             contentDescription = "Profile Image",
                             modifier = Modifier
                                 .size(75.dp)
-                                .clip(CircleShape)
-                                .testTag("profile_image"),
+                                .clip(CircleShape),
                             contentScale = ContentScale.Crop
                         )
                     } else {
                         Icon(
                             imageVector = Icons.Default.AccountCircle,
                             contentDescription = "Profile Image",
-                            modifier = Modifier
-                                .size(75.dp)
-                                .testTag("profile_image")
+                            modifier = Modifier.size(75.dp)
                         )
                     }
 
@@ -343,30 +338,29 @@ fun ProfileCard(
                     Text(
                         text = memberInfo.name,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 16.sp,
-                        modifier = Modifier.testTag("name")
+                        fontSize = 16.sp
                     )
-                    Spacer(modifier = Modifier.height(2.dp))
 
                     Text(
                         text = memberInfo.bio ?: "안녕하세요!",
                         fontSize = 13.sp,
-                        modifier = Modifier.testTag("comment"),
                         maxLines = 2
                     )
 
                     Spacer(modifier = Modifier.height(12.dp))
 
+                    // 팔로워 버튼만 표시 (팔로잉 제거)
                     Button(
                         onClick = onFollowerClick,
                         shape = RoundedCornerShape(20.dp),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
                         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF1F1F1))
                     ) {
                         Text("팔로워 $followerCount", fontSize = 12.sp, color = Color.Black)
                     }
                 }
 
+                // 오른쪽 버튼들
                 Row(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)


### PR DESCRIPTION
# 📑 PR 요약
<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
팔로워/팔로잉 리스트 화면 추가 구현

## 🔗 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
closed #67 

## ☑ 작업 내용
<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->
- 팔로워/팔로잉 리스트 화면 추가 구현
- 팔로워/팔로잉 리스트 화면 사용자 식별성 개선

## 📣 공유사항
<!-- PR과 관련된 내용 공유나 reviewer에 대한 요청사항이 있다면 작성해주세요. -->
- 백엔드 수정 필요

**FriendService.java**
- `getFollowingListWithDetails()` → `List<MemberInfoResponseDto>` 반환
- `getFollowerListWithDetails()` → `List<MemberInfoResponseDto>` 반환
- 기존 `getFollowingList()`, `getFollowerList()` 메서드는 호환성을 위해 유지

**FriendController.java**
- `GET /friends/following`: `List<String>` → `List<MemberInfoResponseDto>` 변경
- `GET /friends/follower`: `List<String>` → `List<MemberInfoResponseDto>` 변경

**MemberInfoResponseDto.java**
- `id` 필드 추가
- 생성자에서 `member.getId()` 매핑 추가
